### PR TITLE
[Fixup] drivers: power: Fix Header Path for oplus_battery_mtk6765R

### DIFF
--- a/drivers/power/oplus/charger_ic/oplus_battery_mtk6765R.h
+++ b/drivers/power/oplus/charger_ic/oplus_battery_mtk6765R.h
@@ -22,13 +22,13 @@
 #include <linux/uaccess.h>
 
 //#include <mt-plat/charger_class.h>
-//#include "../../../../../kernel-4.19/drivers/power/supply/mtk_charger.h"
-//#include "../../../../../kernel-4.19/drivers/power/supply/mtk_battery.h"
-#include "../../../../../kernel-4.19/drivers/power/supply/charger_class.h"
-#include "../../../../../kernel-4.19/drivers/power/supply/adapter_class.h"
-#include "../../../../../kernel-4.19/drivers/power/supply/mtk_pd.h"
-#include "../../../../../kernel-4.19/drivers/power/supply/mtk_charger_algorithm_class.h"
-#include "../../../../../kernel-4.19/drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
+//#include "../drivers/power/supply/mtk_charger.h"
+//#include "../drivers/power/supply/mtk_battery.h"
+#include "../drivers/power/supply/charger_class.h"
+#include "../drivers/power/supply/adapter_class.h"
+#include "../drivers/power/supply/mtk_pd.h"
+#include "../drivers/power/supply/mtk_charger_algorithm_class.h"
+#include "../drivers/misc/mediatek/typec/tcpc/inc/tcpm.h"
 
 #define MAX_ALG_NO 10
 


### PR DESCRIPTION
* The kernel path for mtk power drivers should be ../drivers/misc/mediatek/ , but for some reasons, the path here is ../../../../kernel-4.19/drivers/misc/mediatek/ , this is probably due to oplus's build system , it works fine in their enviroment, but for third party developer it throws error, so lets just define its correct path & fix the error.

Test: Error is fixed & kernel code compiles successfully.

Change-Id: Ie6930c4e0fc80c0453bebe1c9cf3d6cee87174ee
Signed-off-by: techyminati <sinha.aryan03@gmail.com>